### PR TITLE
Use the URL parser to parse the query string

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,7 +11,8 @@
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
-        "elm/parser": "1.0.0 <= v < 2.0.0"
+        "elm/parser": "1.0.0 <= v < 2.0.0",
+        "elm/url": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.0.0 <= v < 2.0.0"

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -15,9 +15,18 @@ lastUrl =
     "https://api.github.com/user/193238/repos?per_page=100&page=3"
 
 
+shortUrl : String
+shortUrl =
+    "https://api.github.com/user/123/repos?page=4"
+
+
 header : String
 header =
-    "<" ++ nextUrl ++ ">; rel=\"next\", <" ++ lastUrl ++ ">; rel=\"last\""
+    String.join ", "
+        [ "<" ++ nextUrl ++ ">; rel=\"next\""
+        , "<" ++ lastUrl ++ ">; rel=\"last\""
+        , "<" ++ shortUrl ++ ">; rel=\"prev\""
+        ]
 
 
 suite : Test
@@ -31,5 +40,6 @@ suite =
                 Expect.equal (LinkHeader.parse header)
                     [ LinkHeader.WebLink (RelNext 2) nextUrl
                     , LinkHeader.WebLink (RelLast 3) lastUrl
+                    , LinkHeader.WebLink (RelPrev 4) shortUrl
                     ]
         ]


### PR DESCRIPTION
E.g. if the page param is the first (or only) query param, looking for
"&page=" will fail. Rather than looking for "page=" or one of
"&page="/"?page=", this switches to using the elm/url library for
parsing the page out of the querystring.
